### PR TITLE
Add proper exception when instance name in service.json did not match AWS instance name

### DIFF
--- a/ymir/service.py
+++ b/ymir/service.py
@@ -420,6 +420,9 @@ class AbstractService(Reporter, FabricMixin, ValidationMixin):
             retrieve information for use without actually displaying it
         """
         instance = util.get_instance_by_name(self.NAME, self.conn)
+        if instance is None:
+            raise SystemExit("Could not find instance {} in AWS".format(self.NAME))
+
         result = dict(
             instanceance=None, ip=None,
             private_ip=None, tags=[],


### PR DESCRIPTION
I received the following error today and had to dig through the code to figure out the issue

"/var/lib/jenkins/shiningpanda/jobs/4d7faba6/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/ymir/util.py", line 108, in ssh_ctx

```
assert ip is not None
AssertionError
```
